### PR TITLE
[FEAT] Add GstSnoopOutput

### DIFF
--- a/docs/zh_CN/changelog.md
+++ b/docs/zh_CN/changelog.md
@@ -9,6 +9,7 @@ title: 更新日志
 **Features**
 
 - 功能：新增`GstStreamOutput`类，支持通过 GStreamer 进行 RTP 推流 #1
+- 功能：新增`GstSnoopOutput`类，支持通过 GStreamer 负责输入与输出，并在中间部分使用回调函数对视频流数据进行处理 #2
 
 **Fixes**
 

--- a/docs/zh_CN/changelog.md
+++ b/docs/zh_CN/changelog.md
@@ -1,0 +1,23 @@
+---
+title: 更新日志
+---
+
+- [更新日志](#更新日志)
+
+# 更新日志
+
+**Features**
+
+- 功能：新增`GstStreamOutput`类，支持通过 GStreamer 进行 RTP 推流 #1
+
+**Fixes**
+
+- 修复：使得`GstRtspStreamOutput`类能够正常工作，支持通过 GStreamer 进行 RTSP 推流 #1
+
+**Building**
+
+- 构建：启用对`examples`文件夹内的示例程序的编译 #1
+
+**Documentation**
+
+- 文档：更新`README.md`，补充对于各类场景的支持矩阵 #1

--- a/examples/gst_snoop_pipeline.cc
+++ b/examples/gst_snoop_pipeline.cc
@@ -1,25 +1,28 @@
 #include <opencv2/opencv.hpp>
+#include <thread>
 
 #include "zetton_stream_gst/sink/gst_snoop_output.h"
 
 int main(int argc, char *argv[]) {
-  // init gstreamer
+  // 0. prepare
+  // 0.1. init gstreamer
   gst_init(&argc, &argv);
 
-  // init snoop pipe
+  // 0.2. init snoop pipe
   std::string pipeline_src =
       "videotestsrc num-buffers=600 ! "
       "video/x-raw,width=(int)640,height=(int)480,"
       "format=(string)RGB,framerate=(fraction)30/1 ! queue ! appsink "
       "name=testsink";
+  // use fakesink instead of fpsdisplaysink to run on headless server
   std::string pipeline_sink =
       "appsrc name=testsource caps=video/x-raw,width=(int)640,height=(int)480,"
       "format=(string)RGB,framerate=(fraction)30/1 ! queue ! videoconvert ! "
-      "fpsdisplaysink";
+      "fakesink";
   GstSnoopOutput pipe(pipeline_src, pipeline_sink);
   pipe.Init();
 
-  // register callback
+  // 1. register callback
   // pipe.RegisterCallback([](GstMapInfo *map) {
   //   g_print("%lu\n", map->size);
   // });
@@ -39,8 +42,17 @@ int main(int argc, char *argv[]) {
               true);  // true: use L2 norm
   });
 
-  // start pipeline
+  // 2. run pipeline
+  // 2.1. start pipeline
+  std::cout << ">>> start pipeline" << std::endl;
   pipe.Start();
+
+  // 2.2. sleep 10 seconds
+  std::cout << ">>> sleep" << std::endl;
+  std::this_thread::sleep_for(std::chrono::seconds(10));
+
+  // 2.3. stop pipeline
+  std::cout << ">>> stop pipeline" << std::endl;
   pipe.Stop();
 
   return 0;

--- a/examples/gst_snoop_pipeline.cc
+++ b/examples/gst_snoop_pipeline.cc
@@ -1,0 +1,47 @@
+#include <opencv2/opencv.hpp>
+
+#include "zetton_stream_gst/sink/gst_snoop_output.h"
+
+int main(int argc, char *argv[]) {
+  // init gstreamer
+  gst_init(&argc, &argv);
+
+  // init snoop pipe
+  std::string pipeline_src =
+      "videotestsrc num-buffers=600 ! "
+      "video/x-raw,width=(int)640,height=(int)480,"
+      "format=(string)RGB,framerate=(fraction)30/1 ! queue ! appsink "
+      "name=testsink";
+  std::string pipeline_sink =
+      "appsrc name=testsource caps=video/x-raw,width=(int)640,height=(int)480,"
+      "format=(string)RGB,framerate=(fraction)30/1 ! queue ! videoconvert ! "
+      "fpsdisplaysink";
+  GstSnoopOutput pipe(pipeline_src, pipeline_sink);
+  pipe.Init();
+
+  // register callback
+  // pipe.RegisterCallback([](GstMapInfo *map) {
+  //   g_print("%lu\n", map->size);
+  // });
+  pipe.RegisterCallback([](GstMapInfo *map) {
+    // on screen display
+    cv::Mat frame(480, 640, CV_8UC3, (char *)map->data, cv::Mat::AUTO_STEP);
+    cv::line(frame, cv::Point(0, 240), cv::Point(640, 240),
+             cv::Scalar(0, 255, 0), 2);
+    cv::putText(frame, "Hello World", cv::Point(10, 30),
+                cv::FONT_HERSHEY_SIMPLEX, 1.0, cv::Scalar(0, 255, 0), 2);
+
+    // do canny to simulate a time consuming operation
+    cv::Mat src_gray, detected_edges, dst;
+    cv::cvtColor(frame, src_gray, cv::COLOR_BGR2GRAY);
+    cv::blur(src_gray, detected_edges, cv::Size(3, 3));
+    cv::Canny(detected_edges, detected_edges, 0, 0, 3,
+              true);  // true: use L2 norm
+  });
+
+  // start pipeline
+  pipe.Start();
+  pipe.Stop();
+
+  return 0;
+}

--- a/include/zetton_stream_gst/sink/gst_snoop_output.h
+++ b/include/zetton_stream_gst/sink/gst_snoop_output.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <gst/app/gstappsink.h>
+#include <gst/app/gstappsrc.h>
+#include <gst/gst.h>
+
+#include <functional>
+#include <iostream>
+#include <string>
+
+#include "glibconfig.h"
+#include "gst/gstpad.h"
+
+/// \brief Class representing a GStreamer pipeline with an input element and an
+/// output element.
+/// \n Signals can be registered for data modification as well as
+/// pipeline state changes.
+class GstSnoopOutput {
+ public:
+  /// \brief Constructor for GstSnoopPipe objects.
+  /// \param pipeline_src String defining the input pipeline.
+  /// \param pipeline_sink String defining the output pipeline.
+  GstSnoopOutput(std::string pipeline_src, std::string pipeline_sink);
+
+  /// \brief Destructor for GstSnoopPipe objects.
+  ~GstSnoopOutput();
+
+ public:
+  /// \brief Method for initializing the pipeline.
+  /// \return True if initialization was successful.
+  bool Init();
+
+  /// \brief Method for starting the pipeline.
+  void Start();
+
+  /// \brief Method for stopping the pipeline.
+  void Stop();
+
+  /// \brief Method for registering a data modification callback.
+  /// \param callback std::function object containing the callback function.
+  void RegisterCallback(std::function<void(GstMapInfo *)> callback);
+
+ private:
+  /// \brief User modifies the data here.
+  /// \param map GstMapInfo object passed by reference containing data to
+  /// modify.
+  /// \return GstFlowReturn object indicating flow status.
+  GstFlowReturn ModifyInData(GstMapInfo *map);
+
+  /// \brief Called when the appsink notifies us that there is a new buffer
+  /// ready for processing.
+  /// \param elt GstElement object passed by reference.
+  /// \param user_data GstSnoopPipe object passed by reference.
+  /// \return GstFlowReturn object indicating flow status.
+  static GstFlowReturn OnNewSampleFromSink(GstElement *elt,
+                                           GstSnoopOutput *user_data);
+
+  /// \brief Called when we get a GstMessage from the source pipeline. When we
+  /// get EOS, we notify the appsrc of it.
+  /// \param bus GstBus object passed by reference.
+  /// \param message GstMessage object passed by reference.
+  /// \param user_data GstSnoopPipe object passed by reference.
+  /// \return gboolean object indicating status.
+  static gboolean OnSourceMessage(GstBus *bus, GstMessage *message,
+                                  GstSnoopOutput *user_data);
+
+  /// \brief Called when we get a GstMessage from the sink pipeline. When we
+  /// get EOS, we exit the mainloop and this testapp.
+  /// \param bus GstBus object passed by reference.
+  /// \param message GstMessage object passed by reference.
+  /// \param user_data GstSnoopPipe object passed by reference.
+  /// \return gboolean object indicating status.
+  static gboolean OnSinkMessage(GstBus *bus, GstMessage *message,
+                                GstSnoopOutput *user_data);
+
+ private:
+  /// \brief GMainLoop object used for GStreamer pipeline.
+  GMainLoop *loop_;
+  /// \brief GstElement object at the beginning of the pipeline.
+  GstElement *src_;
+  /// \brief GstElement object at the end of the pipeline.
+  GstElement *sink_;
+  /// \brief User registered data modification callback function.
+  std::function<void(GstMapInfo *)> callback_;
+
+  /// \brief String defining the input pipeline.
+  std::string pipeline_src_;
+  /// \brief String defining the output pipeline.
+  std::string pipeline_sink_;
+};

--- a/src/zetton_stream_gst/sink/gst_snoop_output.cc
+++ b/src/zetton_stream_gst/sink/gst_snoop_output.cc
@@ -30,7 +30,7 @@ bool GstSnoopOutput::Init() {
     return false;
   }
 
-  g_print("Capture bin launched\n");
+  // g_print("Capture bin launched\n");
 
   // to be notified of messages from this pipeline, mostly EOS
   GstBus *bus = NULL;
@@ -62,7 +62,7 @@ bool GstSnoopOutput::Init() {
     g_main_loop_unref(loop_);
     return false;
   }
-  g_print("Play bin launched\n");
+  // g_print("Play bin launched\n");
 
   // Obtains the testsource element by name from the bin
   GstElement *testsource = NULL;
@@ -79,7 +79,7 @@ bool GstSnoopOutput::Init() {
   gst_bus_add_watch(bus, (GstBusFunc)OnSinkMessage, this);
   gst_object_unref(bus);
 
-  g_print("Going to set state to play\n");
+  // g_print("Going to set state to play\n");
 
   // Returns true upon successful initialization
   return true;
@@ -93,9 +93,9 @@ void GstSnoopOutput::Start() {
 
   // let's run, this loop will quit when the sink pipeline goes EOS or when an
   // error occurs in the source or sink pipelines.
-  g_print("Let's run!\n");
+  // g_print("Let's run!\n");
   g_main_loop_run(loop_);
-  g_print("Going out\n");
+  // g_print("Going out\n");
 }
 
 void GstSnoopOutput::Stop() {
@@ -130,7 +130,7 @@ GstFlowReturn GstSnoopOutput::ModifyInData(GstMapInfo *map) {
 
   dataLength = map->size;
   rdata = map->data;
-  g_print("%s dataLen = %lu\n", __func__, dataLength);
+  // g_print("%s dataLen = %lu\n", __func__, dataLength);
 
   // Modify half of frame to plane white
   // for (gsize i = 0; i <= dataLength / 2; i++) {
@@ -150,7 +150,7 @@ GstFlowReturn GstSnoopOutput::OnNewSampleFromSink(GstElement *elt,
   //   guint8 *rdata;
   //   int dataLength;
   //   int i;
-  g_print("%s\n", __func__);
+  // g_print("%s\n", __func__);
 
   // get the sample from appsink
   sample = gst_app_sink_pull_sample(GST_APP_SINK(elt));
@@ -184,8 +184,8 @@ GstFlowReturn GstSnoopOutput::OnNewSampleFromSink(GstElement *elt,
 gboolean GstSnoopOutput::OnSourceMessage(GstBus *bus, GstMessage *message,
                                          GstSnoopOutput *user_data) {
   GstElement *source;
-  g_print("%s\n", __func__);
-  g_print("%s\n", GST_MESSAGE_TYPE_NAME(message));
+  // g_print("%s\n", __func__);
+  // g_print("%s\n", GST_MESSAGE_TYPE_NAME(message));
 
   // Process messages from the source pipeline
   switch (GST_MESSAGE_TYPE(message)) {
@@ -211,7 +211,7 @@ gboolean GstSnoopOutput::OnSourceMessage(GstBus *bus, GstMessage *message,
 gboolean GstSnoopOutput::OnSinkMessage(GstBus *bus, GstMessage *message,
                                        GstSnoopOutput *user_data) {
   // Process messages from the sink pipeline
-  g_print("%s\n", __func__);
+  // g_print("%s\n", __func__);
   switch (GST_MESSAGE_TYPE(message)) {
     case GST_MESSAGE_EOS:
       // EOS from the sink pipeline, quit the loop

--- a/src/zetton_stream_gst/sink/gst_snoop_output.cc
+++ b/src/zetton_stream_gst/sink/gst_snoop_output.cc
@@ -1,6 +1,7 @@
 #include "zetton_stream_gst/sink/gst_snoop_output.h"
 
 #include <functional>
+#include <thread>
 #include <utility>
 
 GstSnoopOutput::GstSnoopOutput(std::string pipeline_src,
@@ -15,16 +16,16 @@ GstSnoopOutput::~GstSnoopOutput() { Stop(); }
 
 bool GstSnoopOutput::Init() {
   // Initializes the GMainLoop
-  loop_ = g_main_loop_new(NULL, FALSE);
+  loop_ = g_main_loop_new(nullptr, FALSE);
 
   // Setting up source pipeline, we read from a file and convert to our desired
-  gchar *string = NULL;
+  gchar *string = nullptr;
   string = g_strdup_printf("%s", pipeline_src_.c_str());
-  src_ = gst_parse_launch(string, NULL);
+  src_ = gst_parse_launch(string, nullptr);
   g_free(string);
 
   // If source pipeline is faulty, unref loop and return false
-  if (src_ == NULL) {
+  if (src_ == nullptr) {
     g_print("Bad source\n");
     g_main_loop_unref(loop_);
     return false;
@@ -33,16 +34,17 @@ bool GstSnoopOutput::Init() {
   // g_print("Capture bin launched\n");
 
   // to be notified of messages from this pipeline, mostly EOS
-  GstBus *bus = NULL;
+  GstBus *bus = nullptr;
   bus = gst_element_get_bus(src_);
   gst_bus_add_watch(bus, (GstBusFunc)OnSourceMessage, this);
   gst_object_unref(bus);
 
   // we use appsink in push mode, it sends us a signal when data is available
   // and we pull out the data in the signal callback.
-  GstElement *testsink = NULL;
+  GstElement *testsink = nullptr;
   testsink = gst_bin_get_by_name(GST_BIN(src_), "testsink");
-  g_object_set(G_OBJECT(testsink), "emit-signals", TRUE, "sync", FALSE, NULL);
+  g_object_set(G_OBJECT(testsink), "emit-signals", TRUE, "sync", FALSE,
+               nullptr);
   g_signal_connect(testsink, "new-sample", G_CALLBACK(OnNewSampleFromSink),
                    this);
   gst_object_unref(testsink);
@@ -52,11 +54,11 @@ bool GstSnoopOutput::Init() {
   // behaviour on the src which means that we will push the entire file into
   // memory.
   string = g_strdup_printf("%s", pipeline_sink_.c_str());
-  sink_ = gst_parse_launch(string, NULL);
+  sink_ = gst_parse_launch(string, nullptr);
   g_free(string);
 
   // If sink pipeline is faulty, unref source pipeline and loop and return false
-  if (sink_ == NULL) {
+  if (sink_ == nullptr) {
     g_print("Bad sink\n");
     gst_object_unref(src_);
     g_main_loop_unref(loop_);
@@ -65,12 +67,12 @@ bool GstSnoopOutput::Init() {
   // g_print("Play bin launched\n");
 
   // Obtains the testsource element by name from the bin
-  GstElement *testsource = NULL;
+  GstElement *testsource = nullptr;
   testsource = gst_bin_get_by_name(GST_BIN(sink_), "testsource");
   // configures the source to push data in time-based format
-  g_object_set(testsource, "format", GST_FORMAT_TIME, NULL);
+  g_object_set(testsource, "format", GST_FORMAT_TIME, nullptr);
   // uncomment this line to block when appsrc has buffered enough
-  g_object_set(testsource, "block", TRUE, NULL);
+  g_object_set(testsource, "block", TRUE, nullptr);
   gst_object_unref(testsource);
 
   // Adds a watch on the bus to receive messages from the sink pipeline, mostly
@@ -99,7 +101,7 @@ void GstSnoopOutput::Start() {
 }
 
 void GstSnoopOutput::Stop() {
-  // set the source and sink pipelines to NULL
+  // set the source and sink pipelines to nullptr
   gst_element_set_state(src_, GST_STATE_NULL);
   gst_element_set_state(sink_, GST_STATE_NULL);
 

--- a/src/zetton_stream_gst/sink/gst_snoop_output.cc
+++ b/src/zetton_stream_gst/sink/gst_snoop_output.cc
@@ -1,0 +1,230 @@
+#include "zetton_stream_gst/sink/gst_snoop_output.h"
+
+#include <functional>
+#include <utility>
+
+GstSnoopOutput::GstSnoopOutput(std::string pipeline_src,
+                               std::string pipeline_sink)
+    : loop_(nullptr),
+      src_(nullptr),
+      sink_(nullptr),
+      pipeline_src_(std::move(pipeline_src)),
+      pipeline_sink_(std::move(pipeline_sink)) {}
+
+GstSnoopOutput::~GstSnoopOutput() { Stop(); }
+
+bool GstSnoopOutput::Init() {
+  // Initializes the GMainLoop
+  loop_ = g_main_loop_new(NULL, FALSE);
+
+  // Setting up source pipeline, we read from a file and convert to our desired
+  gchar *string = NULL;
+  string = g_strdup_printf("%s", pipeline_src_.c_str());
+  src_ = gst_parse_launch(string, NULL);
+  g_free(string);
+
+  // If source pipeline is faulty, unref loop and return false
+  if (src_ == NULL) {
+    g_print("Bad source\n");
+    g_main_loop_unref(loop_);
+    return false;
+  }
+
+  g_print("Capture bin launched\n");
+
+  // to be notified of messages from this pipeline, mostly EOS
+  GstBus *bus = NULL;
+  bus = gst_element_get_bus(src_);
+  gst_bus_add_watch(bus, (GstBusFunc)OnSourceMessage, this);
+  gst_object_unref(bus);
+
+  // we use appsink in push mode, it sends us a signal when data is available
+  // and we pull out the data in the signal callback.
+  GstElement *testsink = NULL;
+  testsink = gst_bin_get_by_name(GST_BIN(src_), "testsink");
+  g_object_set(G_OBJECT(testsink), "emit-signals", TRUE, "sync", FALSE, NULL);
+  g_signal_connect(testsink, "new-sample", G_CALLBACK(OnNewSampleFromSink),
+                   this);
+  gst_object_unref(testsink);
+
+  // setting up sink pipeline, we push video data into this pipeline that will
+  // then copy in file using the default filesink. We have no blocking
+  // behaviour on the src which means that we will push the entire file into
+  // memory.
+  string = g_strdup_printf("%s", pipeline_sink_.c_str());
+  sink_ = gst_parse_launch(string, NULL);
+  g_free(string);
+
+  // If sink pipeline is faulty, unref source pipeline and loop and return false
+  if (sink_ == NULL) {
+    g_print("Bad sink\n");
+    gst_object_unref(src_);
+    g_main_loop_unref(loop_);
+    return false;
+  }
+  g_print("Play bin launched\n");
+
+  // Obtains the testsource element by name from the bin
+  GstElement *testsource = NULL;
+  testsource = gst_bin_get_by_name(GST_BIN(sink_), "testsource");
+  // configures the source to push data in time-based format
+  g_object_set(testsource, "format", GST_FORMAT_TIME, NULL);
+  // uncomment this line to block when appsrc has buffered enough
+  g_object_set(testsource, "block", TRUE, NULL);
+  gst_object_unref(testsource);
+
+  // Adds a watch on the bus to receive messages from the sink pipeline, mostly
+  // EOS
+  bus = gst_element_get_bus(sink_);
+  gst_bus_add_watch(bus, (GstBusFunc)OnSinkMessage, this);
+  gst_object_unref(bus);
+
+  g_print("Going to set state to play\n");
+
+  // Returns true upon successful initialization
+  return true;
+}
+
+void GstSnoopOutput::Start() {
+  // launch the sink pipeline first, this will block until the source pipeline
+  // goes to PLAYING
+  gst_element_set_state(sink_, GST_STATE_PLAYING);
+  gst_element_set_state(src_, GST_STATE_PLAYING);
+
+  // let's run, this loop will quit when the sink pipeline goes EOS or when an
+  // error occurs in the source or sink pipelines.
+  g_print("Let's run!\n");
+  g_main_loop_run(loop_);
+  g_print("Going out\n");
+}
+
+void GstSnoopOutput::Stop() {
+  // set the source and sink pipelines to NULL
+  gst_element_set_state(src_, GST_STATE_NULL);
+  gst_element_set_state(sink_, GST_STATE_NULL);
+
+  if (src_) {
+    // unref the source pipeline
+    gst_object_unref(src_);
+  }
+  if (sink_) {
+    // unref the sink pipeline
+    gst_object_unref(sink_);
+  }
+  if (loop_) {
+    // unref the loop
+    g_main_loop_unref(loop_);
+  }
+}
+
+void GstSnoopOutput::RegisterCallback(
+    std::function<void(GstMapInfo *)> callback) {
+  // Register callback function
+  callback_ = std::move(callback);
+}
+
+GstFlowReturn GstSnoopOutput::ModifyInData(GstMapInfo *map) {
+  // dummy function to modify data
+  gsize dataLength;
+  guint8 *rdata;
+
+  dataLength = map->size;
+  rdata = map->data;
+  g_print("%s dataLen = %lu\n", __func__, dataLength);
+
+  // Modify half of frame to plane white
+  // for (gsize i = 0; i <= dataLength / 2; i++) {
+  //   rdata[i] = 0xff;
+  // }
+
+  return GST_FLOW_OK;
+}
+
+GstFlowReturn GstSnoopOutput::OnNewSampleFromSink(GstElement *elt,
+                                                  GstSnoopOutput *user_data) {
+  GstSample *sample;
+  GstBuffer *app_buffer, *buffer;
+  GstElement *source;
+  GstFlowReturn ret;
+  GstMapInfo map;
+  //   guint8 *rdata;
+  //   int dataLength;
+  //   int i;
+  g_print("%s\n", __func__);
+
+  // get the sample from appsink
+  sample = gst_app_sink_pull_sample(GST_APP_SINK(elt));
+  buffer = gst_sample_get_buffer(sample);
+
+  // copy the buffer to a new buffer
+  app_buffer = gst_buffer_copy_deep(buffer);
+  // map the buffer
+  gst_buffer_map(app_buffer, &map, GST_MAP_WRITE);
+
+  // modify the buffer data
+  if (user_data->callback_) {
+    user_data->callback_(&map);
+  } else {
+    user_data->ModifyInData(&map);
+  }
+
+  // get the source element by name from the bin
+  source = gst_bin_get_by_name(GST_BIN(user_data->sink_), "testsource");
+  // push the buffer into the appsrc
+  ret = gst_app_src_push_buffer(GST_APP_SRC(source), app_buffer);
+
+  // unref the sample and the buffer
+  gst_sample_unref(sample);
+  gst_buffer_unmap(app_buffer, &map);
+  gst_object_unref(source);
+
+  return ret;
+}
+
+gboolean GstSnoopOutput::OnSourceMessage(GstBus *bus, GstMessage *message,
+                                         GstSnoopOutput *user_data) {
+  GstElement *source;
+  g_print("%s\n", __func__);
+  g_print("%s\n", GST_MESSAGE_TYPE_NAME(message));
+
+  // Process messages from the source pipeline
+  switch (GST_MESSAGE_TYPE(message)) {
+    case GST_MESSAGE_EOS:
+      // EOS from the source pipeline, this means we need to push EOS into the
+      // sink pipeline
+      g_print("The source got dry\n");
+      source = gst_bin_get_by_name(GST_BIN(user_data->sink_), "testsource");
+      gst_app_src_end_of_stream(GST_APP_SRC(source));
+      gst_object_unref(source);
+      break;
+    case GST_MESSAGE_ERROR:
+      // Error from the source pipeline, quit the loop
+      g_print("Received error\n");
+      g_main_loop_quit(user_data->loop_);
+      break;
+    default:
+      break;
+  }
+  return TRUE;
+}
+
+gboolean GstSnoopOutput::OnSinkMessage(GstBus *bus, GstMessage *message,
+                                       GstSnoopOutput *user_data) {
+  // Process messages from the sink pipeline
+  g_print("%s\n", __func__);
+  switch (GST_MESSAGE_TYPE(message)) {
+    case GST_MESSAGE_EOS:
+      // EOS from the sink pipeline, quit the loop
+      g_print("Finished playback\n");
+      g_main_loop_quit(user_data->loop_);
+      break;
+    case GST_MESSAGE_ERROR:
+      // Error from the sink pipeline, quit the loop
+      g_print("Received error\n");
+      g_main_loop_quit(user_data->loop_);
+      break;
+    default:
+      break;
+  }
+  return TRUE;
+}


### PR DESCRIPTION
## Motivation

由 GStreamer 的 pipeline 负责视频流的输入与输出，仅在两者的中间部分提供回调函数接口，以对数据进行读取与修改。回调函数中的数据修改是 inplace，尽量减少数据格式的转换。

## Modification

**Features**

- 功能：新增`GstSnoopOutput`类，支持通过 GStreamer 负责输入与输出，并在中间部分使用回调函数对视频流数据进行处理

## BC-breaking (Optional)

None.

## Use cases (Optional)

见`examples/gst_snoop_pipeline.cc`。

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.

2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.

3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects.

4. The documentation has been modified accordingly, like docstring or example tutorials.
